### PR TITLE
Added support for CEDA short lived credential service via OAuth2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>nl.knmi.adagucservices</groupId>
 	<artifactId>adaguc-services</artifactId>
-	<version>1.0.9</version>
+	<version>1.0.11</version>
 	<packaging>war</packaging>
 
 	<name>adaguc-services</name>
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.9-RC1</version>
+			<version>0.9.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/nl/knmi/adaguc/security/PemX509Tools.java
+++ b/src/main/java/nl/knmi/adaguc/security/PemX509Tools.java
@@ -1,5 +1,6 @@
 package nl.knmi.adaguc.security;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -7,6 +8,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyManagementException;
 import java.security.KeyPair;
@@ -22,10 +24,10 @@ import java.security.SignatureException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -42,28 +44,17 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.pkcs.Attribute;
-import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.BasicConstraints;
-import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.Extensions;
-import org.bouncycastle.asn1.x509.KeyPurposeId;
-import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v1CertificateBuilder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.PKCS8Generator;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
@@ -89,6 +80,7 @@ import nl.knmi.adaguc.tools.Tools;
  */
 
 
+@SuppressWarnings("deprecation")
 public class PemX509Tools {
 
 	/**
@@ -156,7 +148,7 @@ public class PemX509Tools {
 	 * @throws IOException
 	 * @throws CertificateException
 	 */
-	public static X509Certificate readCertificateFromPEM (String fileName) throws IOException, CertificateException{
+	public static X509Certificate readCertificateFromPEMFile (String fileName) throws IOException, CertificateException{
 		PemReader pemReader = new PemReader(new FileReader(fileName));
 		PemObject obj = pemReader.readPemObject();
 		pemReader.close();
@@ -295,7 +287,7 @@ public class PemX509Tools {
 	}
 
 
-	private static String privateKeyToPemString(PrivateKey certHolder) throws IOException {
+	public static String privateKeyToPemString(PrivateKey certHolder) throws IOException {
 		StringWriter str = new StringWriter();
 		JcaPEMWriter pemWriter = new JcaPEMWriter(str);
 		pemWriter.writeObject(certHolder);
@@ -353,12 +345,12 @@ public class PemX509Tools {
 						file.equals("439ce3f7.0") == true || // RootCA         : C=UK, O=eScienceSLCSHierarchy, OU=Authority, CN=SLCS Top Level CA
 						true)
 				{
-					X509Certificate tr = PemX509Tools.readCertificateFromPEM(trustRootsLocation + "/" + file);
+					X509Certificate tr = PemX509Tools.readCertificateFromPEMFile(trustRootsLocation + "/" + file);
 					trust.add(tr);
 				}
 			}
 		}
-		X509Certificate clientCertificate = PemX509Tools.readCertificateFromPEM(clientCertLocation);
+		X509Certificate clientCertificate = PemX509Tools.readCertificateFromPEMFile(clientCertLocation);
 		trust.add(clientCertificate);                        // Client CA: DC=uk, DC=ac, DC=ceda, O=STFC RAL, CN=https://ceda.ac.uk/openid/C3Smagic.C3Smagic
 		CertificateVerifier.verifyCertificate(clientCertificate,trust);
 	}
@@ -492,7 +484,7 @@ public class PemX509Tools {
 		if(clientCertificate!=null){
 			/* Read the client auth certificates */
 			PrivateKey clientPrivateCred = readPrivateKeyFromPEM(clientCertificate);
-			X509Certificate clientCert = readCertificateFromPEM(clientCertificate);
+			X509Certificate clientCert = readCertificateFromPEMFile(clientCertificate);
 			certAndKey = new X509UserCertAndKey(clientCert,clientPrivateCred);
 
 		}
@@ -597,5 +589,12 @@ public class PemX509Tools {
 			e.printStackTrace();
 		}
 		Debug.println("/main");
+	}
+
+	public static X509Certificate readCertificateFromPEMString(String shortLivedCertFromOAuthServiceInPemFormat) throws CertificateException {
+		CertificateFactory cf = CertificateFactory.getInstance("X.509");
+		return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(
+				shortLivedCertFromOAuthServiceInPemFormat.getBytes(StandardCharsets.UTF_8)));
+
 	}
 }

--- a/src/main/java/nl/knmi/adaguc/security/user/User.java
+++ b/src/main/java/nl/knmi/adaguc/security/user/User.java
@@ -18,6 +18,9 @@ public class User {
 
 	@Getter
 	String userId = null;
+	
+	@Getter
+	String openId = null;
 
 	@Getter
 	String dataDir = null;
@@ -39,6 +42,7 @@ public class User {
 	public User(String _id) throws IOException, ElementNotFoundException {
 		Debug.println("New user ID is made :["+_id+"]");
 		String userWorkspace = MainServicesConfigurator.getUserWorkspace();
+		openId = _id;
 		userId = makePosixUserId(_id);
 		homeDir=userWorkspace+"/"+userId;
 		dataDir = homeDir+"/data";
@@ -83,5 +87,7 @@ public class User {
 	public X509UserCertAndKey getCertificate() {
 		return this.userCert;
 	}
+
+
 
 }

--- a/src/main/java/nl/knmi/adaguc/security/user/UserManager.java
+++ b/src/main/java/nl/knmi/adaguc/security/user/UserManager.java
@@ -43,11 +43,11 @@ public class UserManager {
 		if(id == null){
 			throw new AuthenticationExceptionImpl("No user information provided");
 		}
-		id = harmonizeUserId(id);
+		String harmonizedId = harmonizeUserId(id);
 		
-		User user = users.get(id);
+		User user = users.get(harmonizedId);
 		if(user == null){
-			users.put(id, new User(id));
+			users.put(harmonizedId, new User(id));
 			return getUser(id);
 		}
 		return user;

--- a/src/main/java/nl/knmi/adaguc/services/esgfsearch/THREDDSCatalogToHTML.java
+++ b/src/main/java/nl/knmi/adaguc/services/esgfsearch/THREDDSCatalogToHTML.java
@@ -280,7 +280,7 @@ public class THREDDSCatalogToHTML {
 						AuthenticatorInterface authenticator = AuthenticatorFactory.getAuthenticator(request);
 						if(authenticator != null){
 							try {
-								openid = UserManager.getUser(authenticator).getUserId();
+								openid = UserManager.getUser(authenticator).getOpenId();
 							} catch(Exception e){
 								Debug.println("No user information provided: " + e.getMessage());
 							}

--- a/src/main/java/nl/knmi/adaguc/services/oauth2/OAuth2RequestMapper.java
+++ b/src/main/java/nl/knmi/adaguc/services/oauth2/OAuth2RequestMapper.java
@@ -1,21 +1,11 @@
 package nl.knmi.adaguc.services.oauth2;
 
 import java.io.IOException;
-import java.security.InvalidKeyException;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.SignatureException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.util.Vector;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.bouncycastle.operator.OperatorCreationException;
-import org.ietf.jgss.GSSException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -31,11 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import nl.knmi.adaguc.config.MainServicesConfigurator;
-import nl.knmi.adaguc.security.CertificateVerificationException;
 import nl.knmi.adaguc.security.SecurityConfigurator;
 import nl.knmi.adaguc.security.SecurityConfigurator.ComputeNode;
 import nl.knmi.adaguc.tools.ElementNotFoundException;
-import nl.knmi.adaguc.tools.HTTPTools;
 import nl.knmi.adaguc.tools.JSONResponse;
 
 

--- a/src/main/java/nl/knmi/adaguc/services/oauth2/OAuthConfigurator.java
+++ b/src/main/java/nl/knmi/adaguc/services/oauth2/OAuthConfigurator.java
@@ -29,6 +29,7 @@ public class OAuthConfigurator implements nl.knmi.adaguc.config.ConfiguratorInte
       
       
       public String id = null;
+      public String oauthCallbackURL = null;
       public String getConfig() {
         String config = "OAuthAuthLoc: "+OAuthAuthLoc+"\n";
         config += "OAuthTokenLoc: "+OAuthTokenLoc+"\n";
@@ -66,6 +67,8 @@ public class OAuthConfigurator implements nl.knmi.adaguc.config.ConfiguratorInte
         	Debug.println("adaguc-services.oauth2 not configured");
 			return;
 		}
+        
+        
         Vector<XMLElement> providers = null;
         try {
           providers = configReader.get("adaguc-services").get("oauth2").getList("provider");
@@ -91,6 +94,7 @@ public class OAuthConfigurator implements nl.knmi.adaguc.config.ConfiguratorInte
             try{oauthSetting.description = provider.get("description").getValue();}catch(Exception e){}
             try{oauthSetting.logo = provider.get("logo").getValue();}catch(Exception e){}
             try{oauthSetting.registerlink = provider.get("registerlink").getValue();}catch(Exception e){}
+            try{oauthSetting.oauthCallbackURL = provider.get("oauthcallbackurl").getValue();}catch(Exception e){}
             
             oauth2Providers.add(oauthSetting);
             //Debug.println(j+") Found Oauth2 provider "+oauthSetting.id);

--- a/src/main/java/nl/knmi/adaguc/services/pywpsserver/PyWPSServer.java
+++ b/src/main/java/nl/knmi/adaguc/services/pywpsserver/PyWPSServer.java
@@ -180,7 +180,7 @@ public class PyWPSServer extends HttpServlet{
 		String statusLocation=null;
 		String creationTime=null;
 		Debug.println("statusLocationDataAsJSONElementToWPSStatusObject");
-		Debug.println(json.toString());
+		//Debug.println(json.toString());
 		MyXMLParser.XMLElement rootElement = new MyXMLParser.XMLElement();
 		rootElement.parse(json);
 		JSONObject data=new JSONObject();

--- a/src/main/java/nl/knmi/adaguc/services/xml2json/ServiceHelperRequestMapper.java
+++ b/src/main/java/nl/knmi/adaguc/services/xml2json/ServiceHelperRequestMapper.java
@@ -165,6 +165,13 @@ public class ServiceHelperRequestMapper {
 				if (wpsID!=null && test.getString("wpsstatus").equals(PyWPSServer.WPSStatus.PROCESSSUCCEEDED.toString())) {
 					Debug.println("============== OK WPS SUCCESFULLY FINISHED, START COPY TO BASKET ================ ");
 					/* Parse outputs and copy them to local basket */
+					if (user == null){
+						throw new Exception("Error, user is null");
+					}
+					if (user.getDataDir() == null){
+						throw new Exception("Error, user.getDataDir() is null");
+					}
+
 					Vector<XMLElement> processOutputs = rootElement.get("wps:ExecuteResponse").get("wps:ProcessOutputs").getList("wps:Output");
 					for(int j=0;j<processOutputs.size();j++){
 //						Debug.println(j + ")" + processOutputs.get(j).toString());
@@ -176,6 +183,7 @@ public class ServiceHelperRequestMapper {
 						try {
 							XMLElement refObj = processOutputs.get(j).get("wps:Reference");
 							String reference = refObj.getAttrValue("href");
+							Debug.println("Processfolder is " + processFolder);
 							String destLoc = user.getDataDir() + "/" + "/" + processFolder;
 							String basketLocalFilename = FilenameUtils.getBaseName(reference) + "." + FilenameUtils.getExtension(reference);
 							String fullPath = destLoc + "/" + basketLocalFilename;

--- a/src/test/java/nl/knmi/adaguc/authentication/AuthenticatorImplTest.java
+++ b/src/test/java/nl/knmi/adaguc/authentication/AuthenticatorImplTest.java
@@ -70,13 +70,13 @@ public class AuthenticatorImplTest {
 
 		/* Get common name from certificate */
 		Debug.println("  Step 2 - Get CN from verified cert");
-		X509Info x509 = new PemX509Tools().getUserIdFromCertificate(PemX509Tools.readCertificateFromPEM(clientCertLocation));
+		X509Info x509 = new PemX509Tools().getUserIdFromCertificate(PemX509Tools.readCertificateFromPEMFile(clientCertLocation));
 		if(x509 != null){
 			Debug.println("  CN = ["+ x509.getCN()+"]");
 		}
 		assertThat(x509.getCN(),is(clientCN));
 		MvcResult result = mockMvc.perform(get("/user/getuserinfofromcert")
-				.sessionAttr("javax.servlet.request.X509Certificate", PemX509Tools.readCertificateFromPEM(clientCertLocation))
+				.sessionAttr("javax.servlet.request.X509Certificate", PemX509Tools.readCertificateFromPEMFile(clientCertLocation))
 				.contentType(MediaType.APPLICATION_JSON_UTF8).content("{}"))
 				//                .andExpect(status().isMethodNotAllowed())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/src/test/java/nl/knmi/adaguc/tools/PemX509ToolsTests.java
+++ b/src/test/java/nl/knmi/adaguc/tools/PemX509ToolsTests.java
@@ -63,7 +63,7 @@ public class PemX509ToolsTests {
 
 		/* Get common name from certificate */
 		Debug.println("  Step 2 - Get CN from verified cert");
-		X509Info x509 = new PemX509Tools().getUserIdFromCertificate(PemX509Tools.readCertificateFromPEM(clientCertLocation));
+		X509Info x509 = new PemX509Tools().getUserIdFromCertificate(PemX509Tools.readCertificateFromPEMFile(clientCertLocation));
 		if(x509 != null){
 			Debug.println("  CN = ["+ x509.getCN()+"]");
 		}


### PR DESCRIPTION
- The configuration parameter security.trustrootscadirectory needs to be set in order to make the NetCDF library talk with secured services
- Also oauth2.provider.oauthcallbackurl can be set to specift where the OAuth service should return to.